### PR TITLE
implement scoped namespace watching

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This reduces manual intervention, ensures consistency, and keeps your cluster in
 - **Dependent Restarts**: Triggers restarts of dependent kubernetes workloads.
 - **Customizable Intervals**: Configure requeue intervals unitl workload is stable, per workload or globally.
 - **Cycle Detection**: Avoid cyclic dependencies in your workload graph.
+- **Scoped Namespace Watching**: Limit `Cascader` to specific namespaces with the `--watch-namespace` flag.
 - **Prometheus Metrics**: Gain insights into dependency cycles, workloads managed, and restarts performed.
 
 > Note: `Cascader` follows a best-effort restart approach. It updates the `kubectl.kubernetes.io/restartedAt` annotation to trigger dependent workload reloads but does not verify if the restart was successful. For reliability checks, use an external monitoring tool like Prometheus.
@@ -44,6 +45,12 @@ kubectl apply -f https://raw.githubusercontent.com/thurgauerkb/cascader/main/dep
 ```
 
 This will deploy `Cascader` in the `cascader-system` namespace.
+
+### Namespaced Mode
+
+By default, `Cascader` watches all namespaces. To restrict it to specific namespaces, pass the `--watch-namespace` flag. This flag can be repeated or comma-separated to specify multiple namespaces. When set, `Cascader` will only monitor workloads and trigger dependent restarts within those namespaces.
+
+If running in namespaced mode, ensure the associated `Role` and `RoleBinding` are configured accordingly. You can use `deploy/manifests/role.template` and `deploy/manifests/rolebinding.template` as starting points for custom RBAC definitions.
 
 ### Kustomize
 
@@ -178,24 +185,25 @@ If you do not want to use the default annotations, you can customize them by pas
 
 ### Start Parameters
 
-| Parameter                            | Description                                                        | Default                         |
-| :----------------------------------- | :----------------------------------------------------------------- | :------------------------------ |
-| `--deployment-annotation` string     | Annotation key for monitored Deployments                           | `cascader.tkb.ch/deployment`    |
-| `--statefulset-annotation` string    | Annotation key for monitored StatefulSets                          | `cascader.tkb.ch/statefulset`   |
-| `--daemonset-annotation` string      | Annotation key for monitored DaemonSets                            | `cascader.tkb.ch/daemonset`     |
-| `--requeue-after-annotation` string  | Annotation key for requeue interval override                       | `cascader.tkb.ch/requeue-after` |
-| `--requeue-after-default` duration   | Default requeue interval                                           | `5s`                            |
-| `--metrics-enabled`                  | Enable or disable the metrics endpoint                             | `true`                          |
-| `--metrics-bind-address` string      | Metrics server address (e.g., `:8080` for HTTP, `:8443` for HTTPS) | `:8443`                         |
-| `--metrics-secure`                   | Serve metrics over HTTPS                                           | `true`                          |
-| `--enable-http2`                     | Enable HTTP/2 for servers                                          | `false`                         |
-| `--health-probe-bind-address` string | Health and readiness probe address                                 | `:8081`                         |
-| `--leader-elect`                     | Enable leader election                                             | `true`                          |
-| `--log-encoder` string               | Log format (`json`, `console`)                                     | `json`                          |
-| `--log-stacktrace-level` string      | Stacktrace log level (`info`, `error`, `panic`)                    | `panic`                         |
-| `--log-devel`                        | Enable development mode logging                                    | `false`                         |
-| `--version`                          | Show version and exit                                              |
-| `-h`, `--help`                       | Show help and exit                                                 |
+| Parameter                            | Description                                                                     | Default                         |
+| :----------------------------------- | :------------------------------------------------------------------------------ | :------------------------------ |
+| `--deployment-annotation` string     | Annotation key for monitored Deployments                                        | `cascader.tkb.ch/deployment`    |
+| `--statefulset-annotation` string    | Annotation key for monitored StatefulSets                                       | `cascader.tkb.ch/statefulset`   |
+| `--daemonset-annotation` string      | Annotation key for monitored DaemonSets                                         | `cascader.tkb.ch/daemonset`     |
+| `--requeue-after-annotation` string  | Annotation key for requeue interval override                                    | `cascader.tkb.ch/requeue-after` |
+| `--requeue-after-default` duration   | Default requeue interval                                                        | `5s`                            |
+| `--watch-namespace` stringSlice      | Namespaces to watch (can be repeated or comma-separated). Watches all if unset. | ``                              |
+| `--metrics-enabled`                  | Enable or disable the metrics endpoint                                          | `true`                          |
+| `--metrics-bind-address` string      | Metrics server address (e.g., `:8080` for HTTP, `:8443` for HTTPS)              | `:8443`                         |
+| `--metrics-secure`                   | Serve metrics over HTTPS                                                        | `true`                          |
+| `--enable-http2`                     | Enable HTTP/2 for servers                                                       | `false`                         |
+| `--health-probe-bind-address` string | Health and readiness probe address                                              | `:8081`                         |
+| `--leader-elect`                     | Enable leader election                                                          | `true`                          |
+| `--log-encoder` string               | Log format (`json`, `console`)                                                  | `json`                          |
+| `--log-stacktrace-level` string      | Stacktrace log level (`info`, `error`, `panic`)                                 | `panic`                         |
+| `--log-devel`                        | Enable development mode logging                                                 | `false`                         |
+| `--version`                          | Show version and exit                                                           |
+| `-h`, `--help`                       | Show help and exit                                                              |
 
 ## Prometheus Metrics
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -25,7 +25,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-const version string = "v0.0.1"
+const version string = "v0.1.0"
 
 func main() {
 	ctx := ctrl.SetupSignalHandler()

--- a/deploy/kubernetes/cascader.yaml
+++ b/deploy/kubernetes/cascader.yaml
@@ -1,28 +1,29 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:
+  name: cascader-system
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: cascader
-  name: cascader-system
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  name: cascader
+  namespace: cascader-system
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: cascader
-  name: cascader
-  namespace: cascader-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  name: cascader-leader-election
+  namespace: cascader-system
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: cascader
-  name: cascader-leader-election-role
-  namespace: cascader-system
 rules:
   - apiGroups:
       - coordination.k8s.io
@@ -40,7 +41,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: cascader-manager-role
+  name: cascader-manager
 rules:
   - apiGroups:
       - ""
@@ -48,6 +49,8 @@ rules:
       - events
     verbs:
       - create
+      - patch
+      - update
   - apiGroups:
       - apps
     resources:
@@ -79,7 +82,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: cascader-metrics-auth-role
+  name: cascader-metrics-auth
 rules:
   - apiGroups:
       - authentication.k8s.io
@@ -97,15 +100,15 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  name: cascader-leader-election
+  namespace: cascader-system
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: cascader
-  name: cascader-leader-election-rolebinding
-  namespace: cascader-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: cascader-leader-election-role
+  name: cascader-leader-election
 subjects:
   - kind: ServiceAccount
     name: cascader
@@ -114,14 +117,14 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  name: cascader-manager
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: cascader
-  name: cascader
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cascader
+  name: cascader-manager
 subjects:
   - kind: ServiceAccount
     name: cascader
@@ -130,11 +133,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: cascader-metrics-auth-rolebinding
+  name: cascader-metrics-auth
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cascader-metrics-auth-role
+  name: cascader-metrics-auth
 subjects:
   - kind: ServiceAccount
     name: cascader
@@ -143,11 +146,11 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+  name: cascader-metrics
+  namespace: cascader-system
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: cascader
-  name: cascader-metrics
-  namespace: cascader-system
 spec:
   ports:
     - name: https
@@ -230,18 +233,26 @@ spec:
       rules:
         - alert: CascaderCycleDetected
           annotations:
-            description:
-              "A dependency cycle has been detected in the Cascader controller.
-              Namespace: {{ $labels.namespace }}, Name: {{ $labels.name }}, Resource Kind:
-              {{ $labels.resource_kind }}. Please check the corresponding Kubernetes Event
-              for detailed cycle path information."
-            summary:
-              Dependency Cycle Detected in ({{ $labels.namespace }}/{{ $labels.name
-              }})
+            description: |
+              A dependency cycle has been detected in the Cascader controller.
+              Namespace: {{ $labels.namespace }}, Name: {{ $labels.name }}, Resource Kind: {{ $labels.resource_kind }}.
+              Please check the corresponding Kubernetes Event for detailed cycle path information.
+            summary: Dependency Cycle Detected in {{ $labels.namespace }}/{{ $labels.name }}
           expr: cascader_dependency_cycles_detected > 0
           for: 1m
           labels:
             severity: critical
+
+        - alert: CascaderHighRestartRate
+          annotations:
+            description: |
+              Cascader has triggered more than 5 restarts for workload {{ $labels.namespace }}/{{ $labels.name }} (kind: {{ $labels.resource_kind }}) in the last 5 minutes.
+              This may indicate a misconfiguration or unstable rollout.
+            summary: High restart rate detected for {{ $labels.namespace }}/{{ $labels.name }}
+          expr: increase(cascader_restarts_performed_total[5m]) > 5
+          for: 2m
+          labels:
+            severity: warning
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/deploy/kubernetes/cascader.yaml
+++ b/deploy/kubernetes/cascader.yaml
@@ -185,7 +185,7 @@ spec:
     spec:
       containers:
         - name: cascader
-          image: ghcr.io/thurgauerkb/cascader:v0.0.1
+          image: ghcr.io/thurgauerkb/cascader:v0.1.0
           ports:
             - name: metrics
               containerPort: 8443

--- a/deploy/kubernetes/chart/cascader/Chart.yaml
+++ b/deploy/kubernetes/chart/cascader/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.0.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: v0.0.1
+appVersion: v0.1.0

--- a/deploy/kubernetes/manifests/deployment.yaml
+++ b/deploy/kubernetes/manifests/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: cascader
       containers:
         - name: cascader
-          image: ghcr.io/thurgauerkb/cascader:v0.0.1
+          image: ghcr.io/thurgauerkb/cascader:v0.1.0
           livenessProbe:
             httpGet:
               path: /healthz

--- a/deploy/kubernetes/manifests/leader-election-role.yaml
+++ b/deploy/kubernetes/manifests/leader-election-role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: cascader-leader-election-role
+  name: cascader-leader-election
   namespace: cascader-system
   labels:
     app.kubernetes.io/name: cascader

--- a/deploy/kubernetes/manifests/leader-election-rolebinding.yaml
+++ b/deploy/kubernetes/manifests/leader-election-rolebinding.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: cascader-leader-election-rolebinding
+  name: cascader-leader-election
   namespace: cascader-system
   labels:
     app.kubernetes.io/name: cascader
@@ -10,7 +10,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: cascader-leader-election-role
+  name: cascader-leader-election
 subjects:
   - kind: ServiceAccount
     name: cascader

--- a/deploy/kubernetes/manifests/metrics-auth-clusterrole.yaml
+++ b/deploy/kubernetes/manifests/metrics-auth-clusterrole.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: cascader-metrics-auth-role
+  name: cascader-metrics-auth
 rules:
   - apiGroups:
       - authentication.k8s.io

--- a/deploy/kubernetes/manifests/metrics-auth-rolebinding.yaml
+++ b/deploy/kubernetes/manifests/metrics-auth-rolebinding.yaml
@@ -2,11 +2,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: cascader-metrics-auth-rolebinding
+  name: cascader-metrics-auth
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cascader-metrics-auth-role
+  name: cascader-metrics-auth
 subjects:
   - kind: ServiceAccount
     name: cascader

--- a/deploy/kubernetes/manifests/metrics-service.yaml
+++ b/deploy/kubernetes/manifests/metrics-service.yaml
@@ -2,11 +2,11 @@
 apiVersion: v1
 kind: Service
 metadata:
+  name: cascader-metrics
+  namespace: cascader-system
   labels:
     app.kubernetes.io/name: cascader
     app.kubernetes.io/component: controller
-  name: cascader-metrics
-  namespace: cascader-system
 spec:
   ports:
     - name: https

--- a/deploy/kubernetes/manifests/role.template
+++ b/deploy/kubernetes/manifests/role.template
@@ -1,8 +1,9 @@
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: cascader-manager
+  namespace: DESTINATION_NAMESPACE
 rules:
   - apiGroups:
       - ""
@@ -23,3 +24,5 @@ rules:
       - list
       - patch
       - watch
+# vi: ft=yaml
+

--- a/deploy/kubernetes/manifests/rolebinding.template
+++ b/deploy/kubernetes/manifests/rolebinding.template
@@ -1,16 +1,18 @@
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: cascader-manager
+  namespace: DESTINATION_NAMESPACE
   labels:
     app.kubernetes.io/name: cascader
     app.kubernetes.io/component: controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: cascader-manager
 subjects:
   - kind: ServiceAccount
     name: cascader
     namespace: cascader-system
+# vi: ft=yaml

--- a/internal/app/run_test.go
+++ b/internal/app/run_test.go
@@ -37,6 +37,7 @@ func TestRun(t *testing.T) {
 		args := []string{
 			"--leader-elect=false",
 			"--health-probe-bind-address", ":8082",
+			"--metrics-enabled=false",
 		}
 		out := &bytes.Buffer{}
 
@@ -108,7 +109,7 @@ func TestRun(t *testing.T) {
 		assert.EqualError(t, err, "unable to start manager: unable to find leader election namespace: not running in-cluster, please specify LeaderElectionNamespace")
 	})
 
-	t.Run("Not Unique Annotations", func(t *testing.T) {
+	t.Run("Not unique Annotations", func(t *testing.T) {
 		t.Parallel()
 
 		ctx := context.Background()
@@ -124,6 +125,6 @@ func TestRun(t *testing.T) {
 		err := Run(ctx, "v0.0.0", args, out)
 
 		assert.Error(t, err)
-		assert.EqualError(t, err, "annotation values must be unique: duplicate annotation 'cascader.tkb.ch/deployment' found for keys 'Deployment' and 'StatefulSet'")
+		assert.ErrorContains(t, err, "annotation values must be unique: duplicate annotation")
 	})
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,6 +50,7 @@ func (e *HelpError) Is(target error) bool {
 
 // Config holds all configuration options for the application.
 type Config struct {
+	WatchNamespaces        []string      // Namespaces to watch
 	MetricsAddr            string        // Address for the metrics server
 	LeaderElection         bool          // Enable leader election
 	ProbeAddr              string        // Address for health and readiness probes
@@ -79,6 +80,8 @@ func ParseArgs(args []string, out io.Writer, version string) (Config, error) {
 	fs.StringVar(&cfg.DaemonSetAnnotation, "daemonset-annotation", daemonSetAnnotation, "Annotation key for monitored DaemonSets")
 	fs.StringVar(&cfg.RequeueAfterAnnotation, "requeue-after-annotation", requeueAfterAnnotation, "Annotation key for requeue interval override")
 	fs.DurationVar(&cfg.RequeueAfterDefault, "requeue-after-default", 5*time.Second, "Default requeue interval")
+
+	fs.StringSliceVar(&cfg.WatchNamespaces, "watch-namespace", nil, "Namespaces to watch (can be repeated or comma-separated). Watches all if unset.")
 
 	fs.BoolVar(&cfg.EnableMetrics, "metrics-enabled", true, "Enable or disable the metrics endpoint")
 	fs.StringVar(&cfg.MetricsAddr, "metrics-bind-address", ":8443", "Metrics server address (e.g., :8080 for HTTP, :8443 for HTTPS)")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"errors"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -152,6 +153,43 @@ func TestParseArgs(t *testing.T) {
 		assert.IsType(t, &HelpError{}, err)
 		assert.Error(t, err)
 		assert.EqualError(t, err, "Cascader version 0.0.0")
+	})
+
+	t.Run("Multiple namespaces", func(t *testing.T) {
+		t.Parallel()
+
+		args := []string{"--watch-namespace", "ns1", "--watch-namespace", "ns2"}
+		cfg, err := ParseArgs(args, io.Discard, "0.0.0")
+
+		assert.NoError(t, err)
+		assert.Len(t, cfg.WatchNamespaces, 2)
+		assert.Equal(t, "ns1", cfg.WatchNamespaces[0])
+		assert.Equal(t, "ns2", cfg.WatchNamespaces[1])
+	})
+
+	t.Run("Multiple namespaces, comma separated", func(t *testing.T) {
+		t.Parallel()
+
+		args := []string{"--watch-namespace", "ns1,ns2"}
+		cfg, err := ParseArgs(args, io.Discard, "0.0.0")
+
+		assert.NoError(t, err)
+		assert.Len(t, cfg.WatchNamespaces, 2)
+		assert.Equal(t, "ns1", cfg.WatchNamespaces[0])
+		assert.Equal(t, "ns2", cfg.WatchNamespaces[1])
+	})
+
+	t.Run("Multiple namespaces, mixed", func(t *testing.T) {
+		t.Parallel()
+
+		args := []string{"--watch-namespace", "ns1", "--watch-namespace", "ns2,ns3"}
+		cfg, err := ParseArgs(args, io.Discard, "0.0.0")
+
+		assert.NoError(t, err)
+		assert.Len(t, cfg.WatchNamespaces, 3)
+		assert.Equal(t, "ns1", cfg.WatchNamespaces[0])
+		assert.Equal(t, "ns2", cfg.WatchNamespaces[1])
+		assert.Equal(t, "ns3", cfg.WatchNamespaces[2])
 	})
 }
 

--- a/internal/utils/helper.go
+++ b/internal/utils/helper.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/thurgauerkb/cascader/internal/kinds"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 )
 
 const RestartedAtKey string = "kubectl.kubernetes.io/restartedAt"
@@ -52,6 +53,23 @@ func FormatAnnotations(annotations map[string]string) string {
 	}
 	sort.Strings(annotationsList) // Ensure deterministic ordering
 	return strings.Join(annotationsList, ", ")
+}
+
+// ToCacheOptions returns cache.Options configured to watch the given namespaces.
+// If no namespaces are provided, it returns an empty Options which watches all namespaces.
+func ToCacheOptions(watchNamespaces []string) cache.Options {
+	if len(watchNamespaces) == 0 {
+		return cache.Options{}
+	}
+
+	nsMap := make(map[string]cache.Config, len(watchNamespaces))
+	for _, ns := range watchNamespaces {
+		nsMap[ns] = cache.Config{}
+	}
+
+	return cache.Options{
+		DefaultNamespaces: nsMap,
+	}
 }
 
 // ParseTargetRef splits a target reference (e.g. "namespace/name") into its namespace and name.

--- a/internal/utils/helper_test.go
+++ b/internal/utils/helper_test.go
@@ -115,6 +115,38 @@ func TestFormatAnnotations(t *testing.T) {
 	})
 }
 
+func TestToCacheOptions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Empty namespace list returns empty cache options", func(t *testing.T) {
+		t.Parallel()
+
+		opts := ToCacheOptions(nil)
+		assert.Nil(t, opts.DefaultNamespaces)
+	})
+
+	t.Run("Single namespace", func(t *testing.T) {
+		t.Parallel()
+
+		opts := ToCacheOptions([]string{"ns1"})
+		assert.Len(t, opts.DefaultNamespaces, 1)
+		_, exists := opts.DefaultNamespaces["ns1"]
+		assert.True(t, exists)
+	})
+
+	t.Run("Multiple namespaces", func(t *testing.T) {
+		t.Parallel()
+
+		namespaces := []string{"ns1", "ns2", "ns3"}
+		opts := ToCacheOptions(namespaces)
+		assert.Len(t, opts.DefaultNamespaces, 3)
+		for _, ns := range namespaces {
+			_, exists := opts.DefaultNamespaces[ns]
+			assert.True(t, exists, "expected namespace %q to exist in DefaultNamespaces", ns)
+		}
+	})
+}
+
 func TestParseTargetRef(t *testing.T) {
 	t.Parallel()
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -35,14 +35,19 @@ const (
 	daemonSetAnnotation         string = "cascader.tkb.ch/daemonset"
 )
 
-var _ = Describe("Operator in default mode", func() {
+var _ = Describe("Operator in default mode", Ordered, func() {
 	var ns string
 
-	// Run the operator once in the background
-	testutils.StartOperatorWithFlags([]string{
-		"--leader-elect=false",
-		"--health-probe-bind-address=:8082",
-		"--metrics-enabled=false",
+	BeforeAll(func() {
+		testutils.StartOperatorWithFlags([]string{
+			"--leader-elect=false",
+			"--health-probe-bind-address=:8082",
+			"--metrics-enabled=false",
+		})
+	})
+
+	AfterAll(func() {
+		testutils.StopOperator()
 	})
 
 	BeforeEach(func(ctx SpecContext) {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -35,15 +35,22 @@ const (
 	daemonSetAnnotation         string = "cascader.tkb.ch/daemonset"
 )
 
-var _ = Describe("Workload E2E Tests", func() {
+var _ = Describe("Operator in default mode", func() {
 	var ns string
+
+	// Run the operator once in the background
+	testutils.StartOperatorWithFlags([]string{
+		"--leader-elect=false",
+		"--health-probe-bind-address=:8082",
+		"--metrics-enabled=false",
+	})
 
 	BeforeEach(func(ctx SpecContext) {
 		ns = testutils.NSManager.CreateNamespace(ctx)
 	})
 
 	AfterEach(func(ctx SpecContext) {
-		testutils.NSManager.DeleteNamespace(ctx, ns)
+		testutils.NSManager.Cleanup(ctx)
 	})
 
 	It("Ensure Operator is Running", func() {
@@ -838,5 +845,93 @@ var _ = Describe("Workload E2E Tests", func() {
 
 		By(fmt.Sprintf("validating cascader handles concurrent updates to %s", obj3ID))
 		testutils.ContainsLogs(fmt.Sprintf("%q,\"targetID\":%q", successfullTriggerTargetMsg, obj3ID), 1*time.Minute, 2*time.Second)
+	})
+})
+
+var _ = Describe("Operator watching multiple namespaces", func() {
+	AfterEach(func(ctx SpecContext) {
+		testutils.NSManager.Cleanup(ctx)
+	})
+
+	It("Multiple mixed targets in different namespaces", func(ctx SpecContext) {
+		ns1 := testutils.NSManager.CreateNamespace(ctx)
+		ns2 := testutils.NSManager.CreateNamespace(ctx)
+		ns3 := testutils.NSManager.CreateNamespace(ctx)
+
+		testutils.StartOperatorWithFlags([]string{
+			"--leader-elect=false",
+			fmt.Sprintf("--watch-namespace=%s,%s,%s", ns1, ns2, ns3),
+			"--health-probe-bind-address=:8084",
+			"--metrics-enabled=false",
+		})
+
+		obj1Name := testutils.GenerateUniqueName("dep1")
+		obj2Name := testutils.GenerateUniqueName("sts2")
+		obj3Name := testutils.GenerateUniqueName("ds3")
+
+		obj1 := testutils.CreateDeployment(
+			ctx,
+			ns1,
+			obj1Name,
+			testutils.WithAnnotation(statefulSetAnnotation, fmt.Sprintf("%s/%s", ns2, obj2Name)),
+			testutils.WithAnnotation(daemonSetAnnotation, fmt.Sprintf("%s/%s", ns3, obj3Name)),
+		)
+
+		obj2 := testutils.CreateStatefulSet(
+			ctx,
+			ns2,
+			obj2Name,
+		)
+		obj2ID := testutils.GenerateID(obj2)
+
+		obj3 := testutils.CreateDaemonSet(
+			ctx,
+			ns3,
+			obj3Name,
+		)
+		obj3ID := testutils.GenerateID(obj3)
+
+		testutils.RestartResource(ctx, obj1)
+
+		By(fmt.Sprintf("validating cascader fetches the restart of %s", obj2ID))
+		testutils.ContainsLogs(fmt.Sprintf("%q,\"targetID\":%q", successfullTriggerTargetMsg, obj2ID), 1*time.Minute, 2*time.Second)
+
+		By(fmt.Sprintf("validating cascader fetches the restart of %s", obj3ID))
+		testutils.ContainsLogs(fmt.Sprintf("%q,\"targetID\":%q", successfullTriggerTargetMsg, obj3ID), 1*time.Minute, 2*time.Second)
+	})
+
+	It("ignores targets outside of watched namespaces", func(ctx SpecContext) {
+		ns1 := testutils.NSManager.CreateNamespace(ctx)
+		ns2 := testutils.NSManager.CreateNamespace(ctx)
+		nsIgnored := testutils.NSManager.CreateNamespace(ctx)
+
+		testutils.StartOperatorWithFlags([]string{
+			"--leader-elect=false",
+			fmt.Sprintf("--watch-namespace=%s,%s", ns1, ns2), // note: nsIgnored is excluded
+			"--health-probe-bind-address=:8085",
+			"--metrics-enabled=false",
+		})
+
+		obj1Name := testutils.GenerateUniqueName("dep1")
+		obj2Name := testutils.GenerateUniqueName("sts-ignored")
+
+		obj1 := testutils.CreateDeployment(
+			ctx,
+			ns1,
+			obj1Name,
+			testutils.WithAnnotation(statefulSetAnnotation, fmt.Sprintf("%s/%s", nsIgnored, obj2Name)),
+		)
+
+		obj2 := testutils.CreateStatefulSet(
+			ctx,
+			nsIgnored,
+			obj2Name,
+		)
+		obj2ID := testutils.GenerateID(obj2)
+
+		testutils.RestartResource(ctx, obj1)
+
+		By("Validating fetching resource error")
+		testutils.ContainsLogs(fmt.Sprintf("dependency cycle detected: dependency cycle check failed: failed to fetch resource %s: unable to get: %s/%s because of unknown namespace for the cache", obj2ID, nsIgnored, obj2Name), 10*time.Second, 1*time.Second)
 	})
 })

--- a/test/testutils/operator.go
+++ b/test/testutils/operator.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2025 Thurgauer Kantonalbank
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testutils
+
+import (
+	"context"
+	"io"
+	"os"
+	"os/exec"
+	"syscall"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	operatorCmd    *exec.Cmd
+	operatorCancel context.CancelFunc
+)
+
+// StartOperatorWithFlags starts the operator process with the given flags.
+func StartOperatorWithFlags(flags []string) {
+	ctx, cancel := context.WithCancel(context.Background())
+	operatorCancel = cancel
+
+	cmd := exec.CommandContext(ctx, "../../bin/cascader", flags...)
+	cmd.Env = os.Environ()
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	// redirect output so ic an be captured
+	output := io.MultiWriter(LogBuffer, GinkgoWriter)
+	cmd.Stdout = output
+	cmd.Stderr = output
+
+	Expect(cmd.Start()).To(Succeed())
+	operatorCmd = cmd
+
+	// Wait until Operator is ready
+	ContainsLogs("\"Deployment\",\"worker count\":1", 1*time.Minute, 2*time.Second)
+}
+
+// StopOperator stops the operator process.
+func StopOperator() {
+	if operatorCancel != nil {
+		operatorCancel()
+	}
+
+	if operatorCmd != nil && operatorCmd.Process != nil {
+		_ = syscall.Kill(-operatorCmd.Process.Pid, syscall.SIGKILL)
+		operatorCmd.Wait() // nolint:errcheck
+	}
+}

--- a/test/testutils/options.go
+++ b/test/testutils/options.go
@@ -35,6 +35,7 @@ func applyOptions(resource client.Object, opts ...Option) {
 	}
 }
 
+// WithAnnotation sets a annotation for a resource.
 func WithAnnotation(key, value string) Option {
 	return func(resource client.Object) {
 		annotations := resource.GetAnnotations()
@@ -46,6 +47,7 @@ func WithAnnotation(key, value string) Option {
 	}
 }
 
+// WithReplicas sets the replicas for a resource.
 func WithReplicas(replicas int32) Option {
 	return func(resource client.Object) {
 		switch obj := resource.(type) {


### PR DESCRIPTION
This PR adds support for a new `--watch-namespace` flag that allows `Cascader` to operate in namespaced mode, watching only the specified namespaces instead of cluster-wide. This makes it suitable for restricted environments or multitenant clusters.