### PR TITLE
Hardcode LeaderElectionReleaseOnCancel to improve shutdown behavior

### DIFF
--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -103,14 +103,15 @@ func Run(ctx context.Context, version string, args []string, out io.Writer) erro
 
 	// Create and initialize the manager
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Scheme:                 scheme,
-		Metrics:                metricsServerOptions,
-		Logger:                 logger,
-		WebhookServer:          webhookServer,
-		HealthProbeBindAddress: cfg.ProbeAddr,
-		LeaderElection:         cfg.LeaderElection,
-		LeaderElectionID:       "fc1fdccd.cascader.tkb.ch",
-		Cache:                  cacheOpts,
+		Scheme:                        scheme,
+		Metrics:                       metricsServerOptions,
+		Logger:                        logger,
+		WebhookServer:                 webhookServer,
+		HealthProbeBindAddress:        cfg.ProbeAddr,
+		LeaderElection:                cfg.LeaderElection,
+		LeaderElectionID:              "fc1fdccd.cascader.tkb.ch",
+		LeaderElectionReleaseOnCancel: true,
+		Cache:                         cacheOpts,
 	})
 	if err != nil {
 		return fmt.Errorf("unable to create manager: %w", err)


### PR DESCRIPTION
## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

This change ensures that the leader election lock is always released
immediately on shutdown, preventing delays during rolling restarts or
controller restarts in high-availability environments.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
