### PR TITLE
fix(controller): write LastObservedRestart annotation to metadata.annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,8 +172,6 @@ This chaining of dependencies allows you to orchestrate multi-step rollouts auto
 - It does not confirm whether dependent workloads successfully restarted.
 - Use external monitoring tools for verification and reliability checks.
 
-Here’s a revised and well-structured **`Restart Detection`** section for your `README.md`, incorporating all relevant logic, clarifying behavior, and making it user-facing while avoiding internal implementation detail overload:
-
 ### Restart Detection
 
 `Cascader` tracks restart events of source workloads and coordinates dependent restarts accordingly. To do this, it monitors for meaningful changes to the workload that indicate a restart has occurred or is underway.

--- a/internal/controller/deployment_reconciler.go
+++ b/internal/controller/deployment_reconciler.go
@@ -60,7 +60,6 @@ func (r *DeploymentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		WithEventFilter(predicates.NewPredicate(
 			r.AnnotationKindMap,
 			predicates.SpecChanged,
-			predicates.RestartAnnotationChanged,
 			predicates.SingleReplicaPodDeleted,
 			predicates.ScaledToZero,
 			predicates.ScaledFromZero,

--- a/internal/controller/statefulset_reconciler.go
+++ b/internal/controller/statefulset_reconciler.go
@@ -60,7 +60,6 @@ func (r *StatefulSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		WithEventFilter(predicates.NewPredicate(
 			r.AnnotationKindMap,
 			predicates.SpecChanged,
-			predicates.RestartAnnotationChanged,
 			predicates.SingleReplicaPodDeleted,
 			predicates.ScaledToZero,
 			predicates.ScaledFromZero,

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -17,11 +17,9 @@ limitations under the License.
 package controller
 
 import (
-	"time"
-
 	"github.com/thurgauerkb/cascader/internal/targets"
 
-	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // targetIDs returns the list of IDs for a slice of targets.
@@ -33,20 +31,12 @@ func targetIDs(ts []targets.Target) []string {
 	return ids
 }
 
-// restartMarkerUpdated returns true if the annotation for restartedAtKey differs from lastObservedRestartKey.
-// If restartedAtKey is missing, it assumes a restart and returns the current timestamp.
-func restartMarkerUpdated(podTemplate *corev1.PodTemplateSpec, restartedAtKey, lastObservedRestartKey string) (bool, string) {
-	annotations := podTemplate.GetAnnotations()
-	if annotations == nil {
-		return true, time.Now().Format(time.RFC3339)
+// hasAnnotation reports whether a annotation is present.
+func hasAnnotation(obj client.Object, key string) bool {
+	ann := obj.GetAnnotations()
+	if ann == nil {
+		return false
 	}
-
-	restartedAt, lastObservedAt := annotations[restartedAtKey], annotations[lastObservedRestartKey]
-
-	return restartMarkerChanged(restartedAt, lastObservedAt), restartedAt
-}
-
-// restartMarkerChanged reports whether restartedAt differs from lastObservedAt.
-func restartMarkerChanged(restartedAt, lastObservedAt string) bool {
-	return restartedAt != "" && (lastObservedAt == "" || restartedAt != lastObservedAt)
+	_, found := ann[key]
+	return found
 }

--- a/internal/predicates/predicate_test.go
+++ b/internal/predicates/predicate_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/thurgauerkb/cascader/internal/kinds"
-	"github.com/thurgauerkb/cascader/internal/utils"
 	"github.com/thurgauerkb/cascader/test/testutils"
 
 	"github.com/stretchr/testify/assert"
@@ -219,51 +218,6 @@ func TestNewPredicate(t *testing.T) {
 
 		result := predicate.Update(event)
 		assert.False(t, result, "UpdateFunc should return false for missing annotations")
-	})
-
-	t.Run("UpdateFunc - Rollout Restart Detected", func(t *testing.T) {
-		t.Parallel()
-
-		predicate := NewPredicate(annotationKindMap, RestartAnnotationChanged)
-
-		oldObj := &appsv1.StatefulSet{
-			ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{
-					"cascader.tkb.ch/statefulset": "target",
-				},
-			},
-			Spec: appsv1.StatefulSetSpec{
-				Template: corev1.PodTemplateSpec{
-					ObjectMeta: metav1.ObjectMeta{
-						Annotations: map[string]string{
-							utils.LastObservedRestartKey: "2025-01-14T12:00:00Z",
-						},
-					},
-				},
-			},
-		}
-
-		newObj := &appsv1.StatefulSet{
-			ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{
-					"cascader.tkb.ch/statefulset": "target",
-				},
-			},
-			Spec: appsv1.StatefulSetSpec{
-				Template: corev1.PodTemplateSpec{
-					ObjectMeta: metav1.ObjectMeta{
-						Annotations: map[string]string{
-							utils.LastObservedRestartKey: "2025-01-14T12:30:00Z",
-						},
-					},
-				},
-			},
-		}
-
-		event := event.UpdateEvent{ObjectOld: oldObj, ObjectNew: newObj}
-
-		result := predicate.Update(event)
-		assert.True(t, result, "UpdateFunc should return true when rollout restart is detected")
 	})
 
 	t.Run("DeleteFunc - Matching Annotations", func(t *testing.T) {

--- a/internal/predicates/predicate_test.go
+++ b/internal/predicates/predicate_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/thurgauerkb/cascader/internal/kinds"
 	"github.com/thurgauerkb/cascader/internal/utils"
+	"github.com/thurgauerkb/cascader/test/testutils"
 
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
@@ -80,7 +81,10 @@ func TestWrapSingleObjectCheck(t *testing.T) {
 				Template: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
-							{Name: "nginx", Image: "nginx:1.21"},
+							{
+								Name:  testutils.DefaultTestImageName,
+								Image: testutils.DefaultTestImage,
+							},
 						},
 					},
 				},
@@ -115,7 +119,10 @@ func TestNewPredicate(t *testing.T) {
 				Template: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
-							{Name: "nginx", Image: "nginx:1.20"},
+							{
+								Name:  testutils.DefaultTestImageName,
+								Image: testutils.DefaultTestImage,
+							},
 						},
 					},
 				},
@@ -129,7 +136,10 @@ func TestNewPredicate(t *testing.T) {
 				Template: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
-							{Name: "nginx", Image: "nginx:1.21"},
+							{
+								Name:  testutils.DefaultTestImageName,
+								Image: testutils.DefaultTestImage,
+							},
 						},
 					},
 				},
@@ -156,7 +166,10 @@ func TestNewPredicate(t *testing.T) {
 				Template: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
-							{Name: "nginx", Image: "nginx:1.20"},
+							{
+								Name:  testutils.DefaultTestImageName,
+								Image: testutils.DefaultTestImage,
+							},
 						},
 					},
 				},
@@ -172,7 +185,10 @@ func TestNewPredicate(t *testing.T) {
 				Template: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
-							{Name: "nginx", Image: "nginx:1.21"},
+							{
+								Name:  testutils.DefaultTestImageName,
+								Image: "latest",
+							},
 						},
 					},
 				},
@@ -220,7 +236,7 @@ func TestNewPredicate(t *testing.T) {
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							utils.RestartedAtKey: "2025-01-14T12:00:00Z",
+							utils.LastObservedRestartKey: "2025-01-14T12:00:00Z",
 						},
 					},
 				},
@@ -237,7 +253,7 @@ func TestNewPredicate(t *testing.T) {
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							utils.RestartedAtKey: "2025-01-14T12:30:00Z",
+							utils.LastObservedRestartKey: "2025-01-14T12:30:00Z",
 						},
 					},
 				},
@@ -321,7 +337,10 @@ func TestNewPredicate(t *testing.T) {
 				Template: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
-							{Name: "nginx", Image: "nginx:1.21"},
+							{
+								Name:  testutils.DefaultTestImageName,
+								Image: testutils.DefaultTestImage,
+							},
 						},
 					},
 				},
@@ -340,7 +359,10 @@ func TestNewPredicate(t *testing.T) {
 				Template: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
-							{Name: "nginx", Image: "nginx:1.21"},
+							{
+								Name:  testutils.DefaultTestImageName,
+								Image: testutils.DefaultTestImage,
+							},
 						},
 					},
 				},

--- a/internal/predicates/utils.go
+++ b/internal/predicates/utils.go
@@ -84,7 +84,7 @@ func RestartAnnotationChanged(oldObj, newObj client.Object) bool {
 	if err != nil {
 		return false
 	}
-	return oldTpl.Annotations[utils.RestartedAtKey] != newTpl.Annotations[utils.RestartedAtKey]
+	return oldTpl.Annotations[utils.LastObservedRestartKey] != newTpl.Annotations[utils.LastObservedRestartKey]
 }
 
 // extractPodTemplate extracts the PodTemplateSpec from a supported resource.

--- a/internal/predicates/utils.go
+++ b/internal/predicates/utils.go
@@ -22,7 +22,6 @@ import (
 	"hash/fnv"
 
 	"github.com/thurgauerkb/cascader/internal/kinds"
-	"github.com/thurgauerkb/cascader/internal/utils"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -54,37 +53,16 @@ func SpecChanged(oldObj, newObj client.Object) bool {
 		return false
 	}
 
-	// Copy and clear annotations to exclude them from the comparison
-	// DeepCopy ensures we don't accidentally modify the original object
-	oldTplCopy := oldTpl.DeepCopy()
-	oldTplCopy.Annotations = nil
-	newTplCopy := newTpl.DeepCopy()
-	newTplCopy.Annotations = nil
-
-	oldHash, err := hashTemplate(*oldTplCopy)
+	oldHash, err := hashTemplate(*oldTpl)
 	if err != nil {
 		return false
 	}
-	newHash, err := hashTemplate(*newTplCopy)
+	newHash, err := hashTemplate(*newTpl)
 	if err != nil {
 		return false
 	}
 
 	return oldHash != newHash
-}
-
-// RestartAnnotationChanged returns true if the "restartedAt" annotation differs
-// between the old and new objects, indicating that a rollout restart was triggered.
-func RestartAnnotationChanged(oldObj, newObj client.Object) bool {
-	oldTpl, err := extractPodTemplate(oldObj)
-	if err != nil {
-		return false
-	}
-	newTpl, err := extractPodTemplate(newObj)
-	if err != nil {
-		return false
-	}
-	return oldTpl.Annotations[utils.LastObservedRestartKey] != newTpl.Annotations[utils.LastObservedRestartKey]
 }
 
 // extractPodTemplate extracts the PodTemplateSpec from a supported resource.

--- a/internal/predicates/utils_test.go
+++ b/internal/predicates/utils_test.go
@@ -94,7 +94,10 @@ func TestSpecChanged(t *testing.T) {
 				Template: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
-							{Name: "nginx", Image: "nginx:1.20"},
+							{
+								Name:  testutils.DefaultTestImageName,
+								Image: testutils.DefaultTestImage,
+							},
 						},
 					},
 				},
@@ -106,7 +109,10 @@ func TestSpecChanged(t *testing.T) {
 				Template: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
-							{Name: "nginx", Image: "nginx:1.21"},
+							{
+								Name:  testutils.DefaultTestImageName,
+								Image: "latest",
+							},
 						},
 					},
 				},
@@ -125,7 +131,10 @@ func TestSpecChanged(t *testing.T) {
 				Template: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
-							{Name: "nginx", Image: "nginx:1.21"},
+							{
+								Name:  testutils.DefaultTestImageName,
+								Image: testutils.DefaultTestImage,
+							},
 						},
 					},
 				},
@@ -137,7 +146,10 @@ func TestSpecChanged(t *testing.T) {
 				Template: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
-							{Name: "nginx", Image: "nginx:1.21"},
+							{
+								Name:  testutils.DefaultTestImageName,
+								Image: testutils.DefaultTestImage,
+							},
 						},
 					},
 				},
@@ -171,7 +183,7 @@ func TestRestartAnnotationChanged(t *testing.T) {
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							utils.RestartedAtKey: restartedAt,
+							utils.LastObservedRestartKey: restartedAt,
 						},
 					},
 				},
@@ -193,7 +205,7 @@ func TestRestartAnnotationChanged(t *testing.T) {
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							utils.RestartedAtKey: "2025-02-22T12:00:00Z",
+							utils.LastObservedRestartKey: "2025-02-22T12:00:00Z",
 						},
 					},
 				},
@@ -201,7 +213,7 @@ func TestRestartAnnotationChanged(t *testing.T) {
 		}
 
 		depNew := depOld.DeepCopy()
-		depNew.Spec.Template.Annotations[utils.RestartedAtKey] = "2025-02-22T12:05:00Z"
+		depNew.Spec.Template.Annotations[utils.LastObservedRestartKey] = "2025-02-22T12:05:00Z"
 
 		changed := RestartAnnotationChanged(depOld, depNew)
 		assert.True(t, changed, "expected true when restartedAt annotation has changed")
@@ -228,7 +240,7 @@ func TestRestartAnnotationChanged(t *testing.T) {
 
 		// New object now has the restartedAt annotation.
 		depNew.Spec.Template.Annotations = map[string]string{
-			utils.RestartedAtKey: "2025-02-22T12:05:00Z",
+			utils.LastObservedRestartKey: "2025-02-22T12:05:00Z",
 		}
 
 		changed = RestartAnnotationChanged(depOld, depNew)
@@ -242,7 +254,7 @@ func TestRestartAnnotationChanged(t *testing.T) {
 		pod := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
-					utils.RestartedAtKey: "2025-02-22T12:00:00Z",
+					utils.LastObservedRestartKey: "2025-02-22T12:00:00Z",
 				},
 			},
 		}

--- a/internal/targets/daemonset.go
+++ b/internal/targets/daemonset.go
@@ -64,7 +64,7 @@ func (t *DaemonSetTarget) Trigger(ctx context.Context) error {
 		t.kubeClient,
 		ds,
 		&ds.Spec.Template,
-		utils.RestartedAtKey,
+		utils.LastObservedRestartKey,
 		time.Now().Format(time.RFC3339),
 	); err != nil {
 		return fmt.Errorf("failed to patch DaemonSet %s/%s: %w", t.namespace, t.name, err)

--- a/internal/targets/daemonset_test.go
+++ b/internal/targets/daemonset_test.go
@@ -142,8 +142,8 @@ func TestDaemonSetTarget_Reload(t *testing.T) {
 		updatedDaemonSet := &appsv1.DaemonSet{}
 		_ = fakeClient.Get(context.TODO(), client.ObjectKey{Namespace: "default", Name: "test-daemonset"}, updatedDaemonSet)
 
-		assert.Contains(t, updatedDaemonSet.Spec.Template.Annotations, utils.RestartedAtKey)
-		assert.NotEmpty(t, updatedDaemonSet.Spec.Template.Annotations[utils.RestartedAtKey])
+		assert.Contains(t, updatedDaemonSet.Spec.Template.Annotations, utils.LastObservedRestartKey)
+		assert.NotEmpty(t, updatedDaemonSet.Spec.Template.Annotations[utils.LastObservedRestartKey])
 	})
 
 	t.Run("Patch Error", func(t *testing.T) {

--- a/internal/targets/deployment.go
+++ b/internal/targets/deployment.go
@@ -64,7 +64,7 @@ func (t *DeploymentTarget) Trigger(ctx context.Context) error {
 		t.kubeClient,
 		dep,
 		&dep.Spec.Template,
-		utils.RestartedAtKey,
+		utils.LastObservedRestartKey,
 		time.Now().Format(time.RFC3339),
 	); err != nil {
 		return fmt.Errorf("failed to patch Deployment %s/%s: %w", t.namespace, t.name, err)

--- a/internal/targets/deployment_test.go
+++ b/internal/targets/deployment_test.go
@@ -140,8 +140,8 @@ func TestDeploymentTarget_Reload(t *testing.T) {
 		updatedDeployment := &appsv1.Deployment{}
 		_ = fakeClient.Get(context.TODO(), client.ObjectKey{Namespace: "default", Name: "test-deployment"}, updatedDeployment)
 
-		assert.Contains(t, updatedDeployment.Spec.Template.Annotations, utils.RestartedAtKey)
-		assert.NotEmpty(t, updatedDeployment.Spec.Template.Annotations[utils.RestartedAtKey])
+		assert.Contains(t, updatedDeployment.Spec.Template.Annotations, utils.LastObservedRestartKey)
+		assert.NotEmpty(t, updatedDeployment.Spec.Template.Annotations[utils.LastObservedRestartKey])
 	})
 
 	t.Run("Patch Error", func(t *testing.T) {

--- a/internal/targets/statefulset.go
+++ b/internal/targets/statefulset.go
@@ -64,7 +64,7 @@ func (t *StatefulSetTarget) Trigger(ctx context.Context) error {
 		t.kubeClient,
 		sts,
 		&sts.Spec.Template,
-		utils.RestartedAtKey,
+		utils.LastObservedRestartKey,
 		time.Now().Format(time.RFC3339),
 	); err != nil {
 		return fmt.Errorf("failed to patch StatefulSet %s/%s: %w", t.namespace, t.name, err)

--- a/internal/targets/statefulset_test.go
+++ b/internal/targets/statefulset_test.go
@@ -138,8 +138,8 @@ func TestStatefulSetTarget_Reload(t *testing.T) {
 		updatedStatefulSet := &appsv1.StatefulSet{}
 		_ = fakeClient.Get(context.TODO(), client.ObjectKey{Namespace: "default", Name: "test-statefulset"}, updatedStatefulSet)
 
-		assert.Contains(t, updatedStatefulSet.Spec.Template.Annotations, utils.RestartedAtKey)
-		assert.NotEmpty(t, updatedStatefulSet.Spec.Template.Annotations[utils.RestartedAtKey])
+		assert.Contains(t, updatedStatefulSet.Spec.Template.Annotations, utils.LastObservedRestartKey)
+		assert.NotEmpty(t, updatedStatefulSet.Spec.Template.Annotations[utils.LastObservedRestartKey])
 	})
 
 	t.Run("Patch Error", func(t *testing.T) {

--- a/test/e2e/daemonset_test.go
+++ b/test/e2e/daemonset_test.go
@@ -88,6 +88,60 @@ var _ = Describe("DaemonSet Workload", Ordered, func() {
 	},
 	)
 
+	It("Restart Pod twice", func(ctx SpecContext) {
+		obj1Name := testutils.GenerateUniqueName("ds1")
+		obj2Name := testutils.GenerateUniqueName("ds2")
+
+		obj1 := testutils.CreateDaemonSet(
+			ctx,
+			ns,
+			obj1Name,
+			testutils.WithAnnotation(daemonSetAnnotation, obj2Name),
+		)
+		obj1ID := testutils.GenerateID(obj1)
+
+		obj2 := testutils.CreateDaemonSet(
+			ctx,
+			ns,
+			obj2Name,
+		)
+		obj2ID := testutils.GenerateID(obj2)
+
+		testutils.RestartResource(ctx, obj1)
+
+		By(fmt.Sprintf("Detect restart of %s", obj1ID))
+		testutils.ContainsLogs(fmt.Sprintf(
+			"%q,\"workloadID\":%q",
+			restartDetectedMsg,
+			obj1ID,
+		), 1*time.Minute, 2*time.Second)
+
+		By(fmt.Sprintf("Fetches restart of %s", obj2ID))
+		testutils.ContainsLogs(
+			fmt.Sprintf("%q,\"workloadID\":%q,\"targetID\":%q", successfullTriggerTargetMsg, obj1ID, obj2ID),
+			1*time.Minute,
+			2*time.Second,
+		)
+
+		testutils.LogBuffer.Reset()
+
+		testutils.DeleteRandomPod(ctx, obj1)
+
+		By(fmt.Sprintf("Detect restart of %s", obj1ID))
+		testutils.ContainsLogs(fmt.Sprintf(
+			"%q,\"workloadID\":%q",
+			restartDetectedMsg,
+			obj1ID,
+		), 1*time.Minute, 2*time.Second)
+
+		By(fmt.Sprintf("Fetches restart of %s", obj2ID))
+		testutils.ContainsLogs(
+			fmt.Sprintf("%q,\"workloadID\":%q,\"targetID\":%q", successfullTriggerTargetMsg, obj1ID, obj2ID),
+			1*time.Minute,
+			2*time.Second,
+		)
+	})
+
 	It("Single target in different namespaces", func(ctx SpecContext) {
 		obj1Name := testutils.GenerateUniqueName("ds1")
 		obj2Name := testutils.GenerateUniqueName("ds2")

--- a/test/e2e/deployment_test.go
+++ b/test/e2e/deployment_test.go
@@ -86,6 +86,57 @@ var _ = Describe("Deployment workload", Ordered, func() {
 			2*time.Second)
 	})
 
+	It("Delete Pod twice", func(ctx SpecContext) {
+		obj1Name := testutils.GenerateUniqueName("dep1")
+		obj2Name := testutils.GenerateUniqueName("dep2")
+
+		obj1 := testutils.CreateDeployment(
+			ctx,
+			ns,
+			obj1Name,
+			testutils.WithAnnotation(deploymentAnnotation, obj2Name),
+			testutils.WithStartupProbe(5),
+		)
+		obj1ID := testutils.GenerateID(obj1)
+
+		obj2 := testutils.CreateDeployment(
+			ctx,
+			ns,
+			obj2Name,
+		)
+		obj2ID := testutils.GenerateID(obj2)
+
+		testutils.RestartResource(ctx, obj1)
+
+		By(fmt.Sprintf("Detect restart of %s", obj1ID))
+		testutils.ContainsLogs(
+			fmt.Sprintf("%q,\"workloadID\":%q", restartDetectedMsg, obj1ID),
+			1*time.Minute,
+			2*time.Second)
+
+		By(fmt.Sprintf("Fetches restart of %s", obj2ID))
+		testutils.ContainsLogs(
+			fmt.Sprintf("%q,\"workloadID\":%q,\"targetID\":%q", successfullTriggerTargetMsg, obj1ID, obj2ID),
+			1*time.Minute,
+			2*time.Second)
+
+		testutils.LogBuffer.Reset()
+
+		testutils.DeleteRandomPod(ctx, obj1)
+
+		By(fmt.Sprintf("Detect restart of %s", obj1ID))
+		testutils.ContainsLogs(
+			fmt.Sprintf("%q,\"workloadID\":%q", restartDetectedMsg, obj1ID),
+			1*time.Minute,
+			2*time.Second)
+
+		By(fmt.Sprintf("Fetches restart of %s", obj2ID))
+		testutils.ContainsLogs(
+			fmt.Sprintf("%q,\"workloadID\":%q,\"targetID\":%q", successfullTriggerTargetMsg, obj1ID, obj2ID),
+			1*time.Minute,
+			2*time.Second)
+	})
+
 	It("Delete pod of single replica", func(ctx SpecContext) {
 		obj1Name := testutils.GenerateUniqueName("dep1")
 		obj2Name := testutils.GenerateUniqueName("dep2")

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -39,11 +39,12 @@ var (
 )
 
 const (
-	successfullTriggerTargetMsg string = "Successfully triggered reload"
-	restartDetectedMsg          string = "Restart detected, handling targets"
-	deploymentAnnotation        string = "cascader.tkb.ch/deployment"
-	statefulSetAnnotation       string = "cascader.tkb.ch/statefulset"
-	daemonSetAnnotation         string = "cascader.tkb.ch/daemonset"
+	successfullTriggerTargetMsg   string = "Successfully triggered reload"
+	restartDetectedMsg            string = "Restart detected, handling targets"
+	deploymentAnnotation          string = "cascader.tkb.ch/deployment"
+	statefulSetAnnotation         string = "cascader.tkb.ch/statefulset"
+	daemonSetAnnotation           string = "cascader.tkb.ch/daemonset"
+	lastObservedRestartAnnotation string = "cascader.tkb.ch/last-observed-restart"
 )
 
 func TestE2E(t *testing.T) {

--- a/test/e2e/statefulset_test.go
+++ b/test/e2e/statefulset_test.go
@@ -86,6 +86,53 @@ var _ = Describe("StatefulSet workload", Ordered, func() {
 		)
 	})
 
+	It("Restart Pod twice", func(ctx SpecContext) {
+		obj1Name := testutils.GenerateUniqueName("sts1")
+		obj2Name := testutils.GenerateUniqueName("sts2")
+
+		obj1 := testutils.CreateStatefulSet(
+			ctx,
+			ns,
+			obj1Name,
+			testutils.WithAnnotation(statefulSetAnnotation, obj2Name),
+		)
+		obj1ID := testutils.GenerateID(obj1)
+
+		obj2 := testutils.CreateStatefulSet(
+			ctx,
+			ns,
+			obj2Name,
+		)
+		obj2ID := testutils.GenerateID(obj2)
+
+		testutils.RestartResource(ctx, obj1)
+
+		By(fmt.Sprintf("Fetches restart of %s", obj2ID))
+		testutils.ContainsLogs(
+			fmt.Sprintf("%q,\"workloadID\":%q,\"targetID\":%q", successfullTriggerTargetMsg, obj1ID, obj2ID),
+			30*time.Second,
+			2*time.Second,
+		)
+
+		testutils.DeleteRandomPod(ctx, obj1)
+
+		testutils.LogBuffer.Reset()
+
+		By(fmt.Sprintf("Detect restart of %s", obj1ID))
+		testutils.ContainsLogs(
+			fmt.Sprintf("%q,\"workloadID\":%q", restartDetectedMsg, obj1ID),
+			30*time.Second,
+			2*time.Second,
+		)
+
+		By(fmt.Sprintf("Fetches restart of %s", obj2ID))
+		testutils.ContainsLogs(
+			fmt.Sprintf("%q,\"workloadID\":%q,\"targetID\":%q", successfullTriggerTargetMsg, obj1ID, obj2ID),
+			30*time.Second,
+			2*time.Second,
+		)
+	})
+
 	It("Delete Pod with multiple replicas", func(ctx SpecContext) {
 		obj1Name := testutils.GenerateUniqueName("sts1")
 		obj2Name := testutils.GenerateUniqueName("sts2")

--- a/test/testutils/workloads.go
+++ b/test/testutils/workloads.go
@@ -37,7 +37,7 @@ import (
 const (
 	DefaultTestImage       string = "nginx:1.21"
 	DefaultTestImageName   string = "nginx"
-	lastObservedRestartKey string = "kubectl.kubernetes.io/last-observed-restart"
+	lastObservedRestartKey string = "cascader.tkb.ch/last-observed-restart"
 )
 
 // K8sClient is the shared Kubernetes client used in e2e tests.

--- a/test/testutils/workloads.go
+++ b/test/testutils/workloads.go
@@ -22,8 +22,6 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/thurgauerkb/cascader/internal/utils"
-
 	. "github.com/onsi/ginkgo/v2" // nolint:staticcheck
 	. "github.com/onsi/gomega"    // nolint:staticcheck
 
@@ -37,8 +35,9 @@ import (
 )
 
 const (
-	defaultTestImage     string = "nginx:1.21"
-	defaultTestImageName string = "nginx"
+	DefaultTestImage       string = "nginx:1.21"
+	DefaultTestImageName   string = "nginx"
+	lastObservedRestartKey string = "kubectl.kubernetes.io/last-observed-restart"
 )
 
 // K8sClient is the shared Kubernetes client used in e2e tests.
@@ -58,7 +57,7 @@ func CreateDeployment(ctx context.Context, namespace, name string, opts ...Optio
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": name}},
 			Spec: corev1.PodSpec{
-				Containers: []corev1.Container{{Name: defaultTestImageName, Image: defaultTestImage}},
+				Containers: []corev1.Container{{Name: DefaultTestImageName, Image: DefaultTestImage}},
 			},
 		},
 	}
@@ -86,7 +85,7 @@ func CreateStatefulSet(ctx context.Context, namespace, name string, opts ...Opti
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": name}},
 			Spec: corev1.PodSpec{
-				Containers: []corev1.Container{{Name: defaultTestImageName, Image: defaultTestImage}},
+				Containers: []corev1.Container{{Name: DefaultTestImageName, Image: DefaultTestImage}},
 			},
 		},
 	}
@@ -113,7 +112,7 @@ func CreateDaemonSet(ctx context.Context, namespace, name string, opts ...Option
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": name}},
 			Spec: corev1.PodSpec{
-				Containers: []corev1.Container{{Name: defaultTestImageName, Image: defaultTestImage}},
+				Containers: []corev1.Container{{Name: DefaultTestImageName, Image: DefaultTestImage}},
 			},
 		},
 	}
@@ -227,7 +226,7 @@ func RestartResource(ctx context.Context, resource client.Object) {
 	if template.Annotations == nil {
 		template.Annotations = map[string]string{}
 	}
-	template.Annotations[utils.RestartedAtKey] = now
+	template.Annotations[lastObservedRestartKey] = now
 
 	Expect(K8sClient.Patch(ctx, resource, patch)).To(Succeed())
 }


### PR DESCRIPTION
This PR fixes the incorrect placement of the `LastObservedRestart` annotation, which was previously set in `spec.template.metadata.annotations`, causing unintended Pod restarts.

The annotation is now correctly written to `metadata.annotations`, as it is intended to mark the source workload itself—not trigger a Pod rollout.

### Additional changes:
- Renamed helper functions to reflect the `LastObservedRestart` annotation name
- Improved the variable name from `restarted` to `observed` for clarity
- Simplified predicates by removing `RestartAnnotationChanged` and updating `SpecChanged` to hash the full PodTemplateSpec, including annotations
- Added new e2e test cases to verify correct annotation placement and restart behavior

This brings the controller behavior in line with expected restart semantics and avoids unnecessary rollouts.
